### PR TITLE
Updates

### DIFF
--- a/setup/aws-alias.sh
+++ b/setup/aws-alias.sh
@@ -2,6 +2,6 @@ alias aws-get-p2='export instanceId=`aws ec2 describe-instances --filters "Name=
 alias aws-get-t2='export instanceId=`aws ec2 describe-instances --filters "Name=instance-state-name,Values=stopped,Name=instance-type,Values=t2.micro" --query "Reservations[0].Instances[0].InstanceId"` && export instanceId=${instanceId//\"/} && echo $instanceId'
 alias aws-start='aws ec2 start-instances --instance-ids $instanceId && aws ec2 wait instance-running --instance-ids $instanceId && export instanceIp=`aws ec2 describe-instances --filters "Name=instance-id,Values=$instanceId" --query "Reservations[0].Instances[0].PublicIpAddress"` && export instanceIp=${instanceIp//\"/} && echo $instanceIp'
 alias aws-ip='export instanceIp=`aws ec2 describe-instances --filters "Name=instance-id,Values=$instanceId" --query "Reservations[0].Instances[0].PublicIpAddress"` && export instanceIp=${instanceIp//\"/} && echo $instanceIp'
-alias aws-ssh='ssh -X -i ~/.ssh/aws-key.pem ubuntu@$instanceIp'
+alias aws-ssh='ssh -i ~/.ssh/aws-key.pem ubuntu@$instanceIp'
 alias aws-stop='aws ec2 stop-instances --instance-ids $instanceId'
 export instanceId=i-9aa9c282

--- a/setup/aws-alias.sh
+++ b/setup/aws-alias.sh
@@ -1,7 +1,7 @@
-alias aws-get-p2='export instanceId=`aws ec2 describe-instances --filters "Name=instance-state-name,Values=stopped,Name=instance-type,Values=p2.xlarge" --query "Reservations[0].Instances[0].InstanceId"` && echo $instanceId'
-alias aws-get-t2='export instanceId=`aws ec2 describe-instances --filters "Name=instance-state-name,Values=stopped,Name=instance-type,Values=t2.large" --query "Reservations[0].Instances[0].InstanceId"` && echo $instanceId'
-alias aws-start='aws ec2 start-instances --instance-ids $instanceId && aws ec2 wait instance-running --instance-ids $instanceId && export instanceIp=`aws ec2 describe-instances --filters "Name=instance-id,Values=$instanceId" --query "Reservations[0].Instances[0].PublicIpAddress"` && echo $instanceIp'
-alias aws-ip='export instanceIp=`aws ec2 describe-instances --filters "Name=instance-id,Values=$instanceId" --query "Reservations[0].Instances[0].PublicIpAddress"` && echo $instanceIp'
-alias aws-ssh='ssh -i ~/.ssh/aws-key.pem ubuntu@$instanceIp'
+alias aws-get-p2='export instanceId=`aws ec2 describe-instances --filters "Name=instance-state-name,Values=stopped,Name=instance-type,Values=p2.xlarge" --query "Reservations[0].Instances[0].InstanceId"` && export instanceId=${instanceId//\"/} && echo $instanceId'
+alias aws-get-t2='export instanceId=`aws ec2 describe-instances --filters "Name=instance-state-name,Values=stopped,Name=instance-type,Values=t2.micro" --query "Reservations[0].Instances[0].InstanceId"` && export instanceId=${instanceId//\"/} && echo $instanceId'
+alias aws-start='aws ec2 start-instances --instance-ids $instanceId && aws ec2 wait instance-running --instance-ids $instanceId && export instanceIp=`aws ec2 describe-instances --filters "Name=instance-id,Values=$instanceId" --query "Reservations[0].Instances[0].PublicIpAddress"` && export instanceIp=${instanceIp//\"/} && echo $instanceIp'
+alias aws-ip='export instanceIp=`aws ec2 describe-instances --filters "Name=instance-id,Values=$instanceId" --query "Reservations[0].Instances[0].PublicIpAddress"` && export instanceIp=${instanceIp//\"/} && echo $instanceIp'
+alias aws-ssh='ssh -X -i ~/.ssh/aws-key.pem ubuntu@$instanceIp'
 alias aws-stop='aws ec2 stop-instances --instance-ids $instanceId'
 export instanceId=i-9aa9c282


### PR DESCRIPTION
On Ubuntu 16.04, when I run "aws-get-p2", "aws-get-t2", "aws-start" and "aws-ip", these return instanceId and instanceIp in quotes.  Ex: "i-0e3ddf8960" instead of i-0e3ddf8960.  This breaks aws-ssh, aws-start and aws-stop.

I appended "&& export instanceId=${instanceId//\"/}" and the same for instanceIp.

There's probably a more elegant way to do this...but other experience this as well so here's my workaround.