### PR TITLE
Missing trailing slash in sample path, lesson1

### DIFF
--- a/deeplearning1/nbs/lesson1.ipynb
+++ b/deeplearning1/nbs/lesson1.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "path = \"data/dogscats/\"\n",
-    "#path = \"data/dogscats/sample\""
+    "#path = \"data/dogscats/sample\/\""
    ]
   },
   {


### PR DESCRIPTION
Adds a trailing path to the `dogscats/sample` path so you don't get an error later in the notebook.