### PR TITLE
aws-alias.sh:  Add aws-nb alias to open the notebook from the command…

### DIFF
--- a/setup/aws-alias.sh
+++ b/setup/aws-alias.sh
@@ -4,4 +4,26 @@ alias aws-start='aws ec2 start-instances --instance-ids $instanceId && aws ec2 w
 alias aws-ip='export instanceIp=`aws ec2 describe-instances --filters "Name=instance-id,Values=$instanceId" --query "Reservations[0].Instances[0].PublicIpAddress"` && echo $instanceIp'
 alias aws-ssh='ssh -i ~/.ssh/aws-key.pem ubuntu@$instanceIp'
 alias aws-stop='aws ec2 stop-instances --instance-ids $instanceId'
+
+
+
+if [[ `uname` == *"CYGWIN"* ]]
+then
+    # This is cygwin.  Use cygstart to open the notebook
+    alias aws-nb='cygstart http://$instanceIp:8888'
+fi
+
+if [[ `uname` == *"Linux"* ]]
+then
+    # This is linux.  Use xdg-open to open the notebook
+    alias aws-nb='xdg-open http://$instanceIp:8888'
+fi
+
+if [[ `uname` == *"Darwin"* ]]
+then
+    # This is Mac.  Use open to open the notebook
+    alias aws-nb='open http://$instanceIp:8888'
+fi
+
+
 export instanceId=i-9aa9c282


### PR DESCRIPTION
… line.

Here's a handy 'aws-nb' alias command that lets you easily open the default web browser to the jupyter notbook on your server.  I find it handy.  Take it or leave it :-)


By adding an aws-nb command, it makes it even less necessary to have a
static IP (elastic IP) address for the servers.

Mac, Linux and cygwin all have different commands to do the
'desktop-open' thing, so this figures out which OS you're on, and uses
the right command to open the default web browser to the right IP
address.