### PR TITLE
Fix aws-ssh alias in setup shell script

### DIFF
--- a/setup/aws-alias.sh
+++ b/setup/aws-alias.sh
@@ -2,6 +2,6 @@ alias aws-get-p2='export instanceId=`aws ec2 describe-instances --filters "Name=
 alias aws-get-t2='export instanceId=`aws ec2 describe-instances --filters "Name=instance-state-name,Values=stopped,Name=instance-type,Values=t2.large" --query "Reservations[0].Instances[0].InstanceId"` && echo $instanceId'
 alias aws-start='aws ec2 start-instances --instance-ids $instanceId && aws ec2 wait instance-running --instance-ids $instanceId && export instanceIp=`aws ec2 describe-instances --filters "Name=instance-id,Values=$instanceId" --query "Reservations[0].Instances[0].PublicIpAddress"` && echo $instanceIp'
 alias aws-ip='export instanceIp=`aws ec2 describe-instances --filters "Name=instance-id,Values=$instanceId" --query "Reservations[0].Instances[0].PublicIpAddress"` && echo $instanceIp'
-alias aws-ssh='ssh -i ~/.ssh/aws-key.pem ubuntu@$instanceIp'
+alias aws-ssh='ssh -i ~/.ssh/aws-key-fast-ai.pem ubuntu@$instanceIp'
 alias aws-stop='aws ec2 stop-instances --instance-ids $instanceId'
 export instanceId=i-9aa9c282


### PR DESCRIPTION
The directory for the ssh pem file is incorrect in the current setup shell script.