### PR TITLE
comment out the reboot instructions

### DIFF
--- a/setup/setup_p2.sh
+++ b/setup/setup_p2.sh
@@ -75,7 +75,7 @@ echo \# Stop your instance: : >> $name-commands.txt
 echo aws ec2 stop-instances --instance-ids $instanceId  >> $name-commands.txt
 echo \# Start your instance: >> $name-commands.txt 
 echo aws ec2 start-instances --instance-ids $instanceId  >> $name-commands.txt
-echo Reboot your instance: >> $name-commands.txt 
+echo \# Reboot your instance: >> $name-commands.txt
 echo aws ec2 reboot-instances --instance-ids $instanceId  >> $name-commands.txt
 echo "" 
 # export vars to be sure

--- a/setup/setup_t2.sh
+++ b/setup/setup_t2.sh
@@ -75,7 +75,7 @@ echo \# Stop your instance: : >> $name-commands.txt
 echo aws ec2 stop-instances --instance-ids $instanceId  >> $name-commands.txt
 echo \# Start your instance: >> $name-commands.txt 
 echo aws ec2 start-instances --instance-ids $instanceId  >> $name-commands.txt
-echo Reboot your instance: >> $name-commands.txt 
+echo \# Reboot your instance: >> $name-commands.txt
 echo aws ec2 reboot-instances --instance-ids $instanceId  >> $name-commands.txt
 echo "" 
 # export vars to be sure


### PR DESCRIPTION
This makes the instructions for rebooting an instance have an initial comment marker, to be consistent with the start/stop instructions.