### PR TITLE
Remove tick marks from the images displayed using plots()

### DIFF
--- a/deeplearning1/nbs/utils.py
+++ b/deeplearning1/nbs/utils.py
@@ -75,8 +75,9 @@ def plots(ims, figsize=(12,6), rows=1, interp=False, titles=None):
     f = plt.figure(figsize=figsize)
     for i in range(len(ims)):
         sp = f.add_subplot(rows, len(ims)//rows, i+1)
+        sp.axis('Off')
         if titles is not None:
-            sp.set_title(titles[i], fontsize=18)
+            sp.set_title(titles[i], fontsize=16)
         plt.imshow(ims[i], interpolation=None if interp else 'none')
 
 


### PR DESCRIPTION
This PR modifies the plots() function in utils.py so it won't show the axis tick-marks and labels on the plots (which are unnecessary for images anyway). The tick labels overlap with image titles when the number of rows is more than one.
`plots(imgs, titles=t, rows=4)`
Before:
![selection_144](https://cloud.githubusercontent.com/assets/2578089/22187713/1b447c90-e0c0-11e6-9de3-8337a4a91d39.png)
After:
![selection_145](https://cloud.githubusercontent.com/assets/2578089/22187726/565c16c6-e0c0-11e6-9a97-339a9b217f03.png)
