### PR TITLE
change created instance from  t2.xlarge to t2.micro

### DIFF
--- a/setup/setup_t2.sh
+++ b/setup/setup_t2.sh
@@ -63,7 +63,7 @@ then
 	chmod 400 ~/.ssh/aws-key-$name.pem
 fi
 
-export instanceId=`aws ec2 run-instances --image-id $ami --count 1 --instance-type t2.xlarge --key-name aws-key-$name --security-group-ids $securityGroupId --subnet-id $subnetId --associate-public-ip-address --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 128, \"VolumeType\": \"gp2\" } } ]" --query 'Instances[0].InstanceId' --output text`
+export instanceId=`aws ec2 run-instances --image-id $ami --count 1 --instance-type t2.micro --key-name aws-key-$name --security-group-ids $securityGroupId --subnet-id $subnetId --associate-public-ip-address --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 128, \"VolumeType\": \"gp2\" } } ]" --query 'Instances[0].InstanceId' --output text`
 aws ec2 create-tags --resources $instanceId --tags --tags Key=Name,Value=$name-gpu-machine
 export allocAddr=`aws ec2 allocate-address --domain vpc --query 'AllocationId' --output text`
 


### PR DESCRIPTION
I understand that  the purpose  of this script is to help setup a "free" instance at AWS EC2. 
According to AWS the "free tier" gives access to  a t2.micro instance and not a t2.xlarge.
source: https://aws.amazon.com/s/dm/optimization/server-side-test/free-tier/free_nc/#details