### PR TITLE
Added output_shape to avoid warnings

### DIFF
--- a/deeplearning1/nbs/vgg16.py
+++ b/deeplearning1/nbs/vgg16.py
@@ -65,7 +65,7 @@ class Vgg16():
 
     def create(self):
         model = self.model = Sequential()
-        model.add(Lambda(vgg_preprocess, input_shape=(3,224,224)))
+        model.add(Lambda(vgg_preprocess, input_shape=(3,224,224), output_shape=(3,224,224)))
 
         self.ConvBlock(2, 64)
         self.ConvBlock(2, 128)

--- a/deeplearning1/nbs/vgg16bn.py
+++ b/deeplearning1/nbs/vgg16bn.py
@@ -69,7 +69,7 @@ class Vgg16BN():
             include_top=False
 
         model = self.model = Sequential()
-        model.add(Lambda(vgg_preprocess, input_shape=(3,)+size))
+        model.add(Lambda(vgg_preprocess, input_shape=(3,)+size, output_shape=(3,)+size))
 
         self.ConvBlock(2, 64)
         self.ConvBlock(2, 128)


### PR DESCRIPTION
This fix addresses the warnings that occur as a result of Keras changes.

http://forums.fast.ai/t/warning-output-shape-argument-not-specified/416/2
https://github.com/fchollet/keras/pull/4543/files
