### PR TITLE
Reset class list in Vgg16.finetune().

### DIFF
--- a/deeplearning1/nbs/vgg16.py
+++ b/deeplearning1/nbs/vgg16.py
@@ -95,11 +95,11 @@ class Vgg16():
         self.compile()
 
     def finetune(self, batches):
-        model = self.model
-        model.pop()
-        for layer in model.layers: layer.trainable=False
-        model.add(Dense(batches.nb_class, activation='softmax'))
-        self.compile()
+        self.ft(batches.nb_class)
+        classes = list(iter(batches.class_indices))
+        for c in batches.class_indices:
+            classes[batches.class_indices[c]] = c
+        self.classes = classes
 
 
     def compile(self, lr=0.001):


### PR DESCRIPTION
`finetune()` resets the model's output layer to effectively a new list of classes.  This makes the old list obsolete and confuses the user when subsequent calls to `predict()` return irrelevant class names.

This change makes `finetune()` update `self.classes` to the new list of classes discovered by the image generator.

See, eg:
- http://forums.fast.ai/t/lesson-1-discussion/96/15
- http://forums.fast.ai/t/lesson-1-discussion/96/313
- http://forums.fast.ai/t/lesson-1-discussion/96/315
- http://forums.fast.ai/t/lesson-1-discussion/96/377