### PR TITLE
Use dollar parens instead of backticks for command substitution

### DIFF
--- a/setup/setup_instance.sh
+++ b/setup/setup_instance.sh
@@ -27,24 +27,24 @@ if [ -z "$(aws configure get aws_access_key_id)" ]; then
     exit 1
 fi
 
-export vpcId=`aws ec2 create-vpc --cidr-block 10.0.0.0/28 --query 'Vpc.VpcId' --output text`
+export vpcId=$(aws ec2 create-vpc --cidr-block 10.0.0.0/28 --query 'Vpc.VpcId' --output text)
 aws ec2 create-tags --resources $vpcId --tags --tags Key=Name,Value=$name
 aws ec2 modify-vpc-attribute --vpc-id $vpcId --enable-dns-support "{\"Value\":true}"
 aws ec2 modify-vpc-attribute --vpc-id $vpcId --enable-dns-hostnames "{\"Value\":true}"
 
-export internetGatewayId=`aws ec2 create-internet-gateway --query 'InternetGateway.InternetGatewayId' --output text`
+export internetGatewayId=$(aws ec2 create-internet-gateway --query 'InternetGateway.InternetGatewayId' --output text)
 aws ec2 create-tags --resources $internetGatewayId --tags --tags Key=Name,Value=$name-gateway
 aws ec2 attach-internet-gateway --internet-gateway-id $internetGatewayId --vpc-id $vpcId
 
-export subnetId=`aws ec2 create-subnet --vpc-id $vpcId --cidr-block 10.0.0.0/28 --query 'Subnet.SubnetId' --output text`
+export subnetId=$(aws ec2 create-subnet --vpc-id $vpcId --cidr-block 10.0.0.0/28 --query 'Subnet.SubnetId' --output text)
 aws ec2 create-tags --resources $internetGatewayId --tags --tags Key=Name,Value=$name-subnet
 
-export routeTableId=`aws ec2 create-route-table --vpc-id $vpcId --query 'RouteTable.RouteTableId' --output text`
+export routeTableId=$(aws ec2 create-route-table --vpc-id $vpcId --query 'RouteTable.RouteTableId' --output text)
 aws ec2 create-tags --resources $routeTableId --tags --tags Key=Name,Value=$name-route-table
-export routeTableAssoc=`aws ec2 associate-route-table --route-table-id $routeTableId --subnet-id $subnetId --output text`
+export routeTableAssoc=$(aws ec2 associate-route-table --route-table-id $routeTableId --subnet-id $subnetId --output text)
 aws ec2 create-route --route-table-id $routeTableId --destination-cidr-block 0.0.0.0/0 --gateway-id $internetGatewayId
 
-export securityGroupId=`aws ec2 create-security-group --group-name $name-security-group --description "SG for fast.ai machine" --vpc-id $vpcId --query 'GroupId' --output text`
+export securityGroupId=$(aws ec2 create-security-group --group-name $name-security-group --description "SG for fast.ai machine" --vpc-id $vpcId --query 'GroupId' --output text)
 # ssh
 aws ec2 authorize-security-group-ingress --group-id $securityGroupId --protocol tcp --port 22 --cidr $cidr
 # jupyter notebook
@@ -61,16 +61,16 @@ then
 	chmod 400 ~/.ssh/aws-key-$name.pem
 fi
 
-export instanceId=`aws ec2 run-instances --image-id $ami --count 1 --instance-type $instanceType --key-name aws-key-$name --security-group-ids $securityGroupId --subnet-id $subnetId --associate-public-ip-address --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 128, \"VolumeType\": \"gp2\" } } ]" --query 'Instances[0].InstanceId' --output text`
+export instanceId=$(aws ec2 run-instances --image-id $ami --count 1 --instance-type $instanceType --key-name aws-key-$name --security-group-ids $securityGroupId --subnet-id $subnetId --associate-public-ip-address --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 128, \"VolumeType\": \"gp2\" } } ]" --query 'Instances[0].InstanceId' --output text)
 aws ec2 create-tags --resources $instanceId --tags --tags Key=Name,Value=$name-gpu-machine
-export allocAddr=`aws ec2 allocate-address --domain vpc --query 'AllocationId' --output text`
+export allocAddr=$(aws ec2 allocate-address --domain vpc --query 'AllocationId' --output text)
 
 echo Waiting for instance start...
 aws ec2 wait instance-running --instance-ids $instanceId
 sleep 10 # wait for ssh service to start running too
-export assocId=`aws ec2 associate-address --instance-id $instanceId --allocation-id $allocAddr --query 'AssociationId' --output text`
-export instanceUrl=`aws ec2 describe-instances --instance-ids $instanceId --query 'Reservations[0].Instances[0].PublicDnsName' --output text`
-#export ebsVolume=`aws ec2 describe-instance-attribute --instance-id $instanceId --attribute  blockDeviceMapping  --query BlockDeviceMappings[0].Ebs.VolumeId --output text`
+export assocId=$(aws ec2 associate-address --instance-id $instanceId --allocation-id $allocAddr --query 'AssociationId' --output text)
+export instanceUrl=$(aws ec2 describe-instances --instance-ids $instanceId --query 'Reservations[0].Instances[0].PublicDnsName' --output text)
+#export ebsVolume=$(aws ec2 describe-instance-attribute --instance-id $instanceId --attribute  blockDeviceMapping  --query BlockDeviceMappings[0].Ebs.VolumeId --output text)
 
 # reboot instance, because I was getting "Failed to initialize NVML: Driver/library version mismatch"
 # error when running the nvidia-smi command

--- a/setup/setup_p2.sh
+++ b/setup/setup_p2.sh
@@ -3,7 +3,7 @@
 # Configure a p2.xlarge instance
 
 # get the correct ami
-export region=`aws configure get region`
+export region=$(aws configure get region)
 if [ $region = "us-west-2" ]; then
    export ami="ami-bc508adc" # Oregon
 elif [ $region = "eu-west-1" ]; then

--- a/setup/setup_t2.sh
+++ b/setup/setup_t2.sh
@@ -3,7 +3,7 @@
 # Configure a t2.xlarge instance
 
 # get the correct ami
-export region=`aws configure get region`
+export region=$(aws configure get region)
 if [ $region = "us-west-2" ]; then
    export ami="ami-f8fd5998" # Oregon
 elif [ $region = "eu-west-1" ]; then


### PR DESCRIPTION
Some users have reported errors running the setup scripts:

http://forums.fast.ai/t/setup-problems-aws/116/360?u=z0k
http://forums.fast.ai/t/setup-problems-aws/116/362?u=z0k

Using dollar parens instead of back-ticks seems to [resolve the problem](http://forums.fast.ai/t/setup-problems-aws/116/365?u=z0k). 

Further reference for a discussion of [back-ticks versus dollar parens](http://unix.stackexchange.com/questions/126927/have-backticks-i-e-cmd-in-sh-shells-been-deprecated). 