### PR TITLE
Pin keras to 1.2.2 as notebooks use Keras 1.x API

### DIFF
--- a/setup/install-gpu-azure.sh
+++ b/setup/install-gpu-azure.sh
@@ -24,7 +24,7 @@ echo "[global]
 device = gpu
 floatX = float32" > ~/.theanorc
 
-pip install keras
+pip install keras==1.2.2
 mkdir ~/.keras
 echo '{
     "image_dim_ordering": "th",

--- a/setup/install-gpu.sh
+++ b/setup/install-gpu.sh
@@ -36,7 +36,7 @@ floatX = float32
 root = /usr/local/cuda" > ~/.theanorc
 
 # install and configure keras
-pip install keras
+pip install keras==1.2.2
 mkdir ~/.keras
 echo '{
     "image_dim_ordering": "th",


### PR DESCRIPTION
pip by default will install keras 2.0.0. In lesson one where `import utils` executes, it fails because keras is missing `activity_l2`, as a result of this change https://github.com/fchollet/keras/commit/1c630c3e3c8969b40a47d07b9f2edda50ec69720. I'm not too familiar with Keras so thought pinning it for now will fix the issue for any new students starting.