### PR TITLE
MixIterator typo fix in next method.

### DIFF
--- a/deeplearning1/nbs/utils.py
+++ b/deeplearning1/nbs/utils.py
@@ -243,8 +243,8 @@ class MixIterator(object):
     def next(self, *args, **kwargs):
         if self.multi:
             nexts = [[next(it) for it in o] for o in self.iters]
-            n0s = np.concatenate([n[0] for n in o])
-            n1s = np.concatenate([n[1] for n in o])
+            n0 = np.concatenate([n[0] for n in nexts])
+            n1 = np.concatenate([n[1] for n in nexts])
             return (n0, n1)
         else:
             nexts = [next(it) for it in self.iters]


### PR DESCRIPTION
Fixes a small typo in the MixIterator class. n0s and n1s were unused.