### PR TITLE
batches shuffle must be set to False when pre-computing features

### DIFF
--- a/deeplearning1/nbs/statefarm.ipynb
+++ b/deeplearning1/nbs/statefarm.ipynb
@@ -716,6 +716,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# batches shuffle must be set to False when pre-computing features\n",
+    "batches = get_batches(path+'train', batch_size=batch_size, shuffle=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 16,
    "metadata": {
     "collapsed": false
@@ -2408,7 +2420,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   },
   "nav_menu": {},
   "nbpresent": {
@@ -2466,10 +2478,6 @@
    "toc_cell": false,
    "toc_section_display": "block",
    "toc_window_display": false
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The proposed change is in statefarm notebook.
currently the batches' (get_batches for the training data) shuffle parameter isn't set to False, before pre-calculating the output of the convolutional layers (conv_feat).  This breaks the connection between the conv_feat to their respected labels.
Before calculating conv_feat the batches' shuffle should be set to False:
`batches = get_batches(path+'train', batch_size=batch_size, shuffle=False)`