### PR TITLE
Replace platform.ai with files.fast.ai

### DIFF
--- a/deeplearning1/nbs/vgg16.py
+++ b/deeplearning1/nbs/vgg16.py
@@ -28,7 +28,7 @@ class Vgg16():
 
 
     def __init__(self):
-        self.FILE_PATH = 'http://www.platform.ai/models/'
+        self.FILE_PATH = 'http://files.fast.ai/models/'
         self.create()
         self.get_classes()
 


### PR DESCRIPTION
Simple URL replacement for downloading the VGG16 models.

Quite critical since platform.ai seems to be down.

Thanks!