### PR TITLE
Update still-broken setup scripts to use files.fast.ai

### DIFF
--- a/setup/install-gpu-azure.sh
+++ b/setup/install-gpu-azure.sh
@@ -33,7 +33,7 @@ echo '{
     "backend": "theano"
 }' > ~/.keras/keras.json
 
-wget http://platform.ai/files/cudnn.tgz
+wget http://files.fast.ai/files/cudnn.tgz
 tar -zxf cudnn.tgz
 cd cuda
 sudo cp lib64/* /usr/local/cuda/lib64/

--- a/setup/install-gpu.sh
+++ b/setup/install-gpu.sh
@@ -46,7 +46,7 @@ echo '{
 }' > ~/.keras/keras.json
 
 # install cudnn libraries
-wget "http://platform.ai/files/cudnn.tgz" -O "cudnn.tgz"
+wget "http://files.fast.ai/files/cudnn.tgz" -O "cudnn.tgz"
 tar -zxf cudnn.tgz
 cd cuda
 sudo cp lib64/* /usr/local/cuda/lib64/


### PR DESCRIPTION
The previous PR updating urls to files.fast.ai didn't fix the instance setup scripts. This PR fixes them.