### PR TITLE
`predict_generator` in `vgg.test` is using a wrong number of interations...?

### DIFF
--- a/deeplearning1/nbs/vgg16.py
+++ b/deeplearning1/nbs/vgg16.py
@@ -223,5 +223,5 @@ class Vgg16():
     
         """
         test_batches = self.get_batches(path, shuffle=False, batch_size=batch_size, class_mode=None)
-        return test_batches, self.model.predict_generator(test_batches, test_batches.nb_sample)
+        return test_batches, self.model.predict_generator(test_batches, test_batches.nb_sample // batch_size + 1)
 


### PR DESCRIPTION

I think you should divide by batch size and round up in for the number of iterations`self.model.predict_generator` runs (so `self.model.predict_generator(test_batches, test_batches.nb_sample // batch_size + 1)` instead of `self.model.predict_generator(test_batches, test_batches.nb_sample)` otherwise keras will take forever to finish predicting because it is not taking advantage (or doing it over and over) of the batches...