### PR TITLE
fix issue with incorrect input dimensions to model.

### DIFF
--- a/deeplearning1/nbs/lesson6.ipynb
+++ b/deeplearning1/nbs/lesson6.ipynb
@@ -1580,7 +1580,7 @@
     }
    ],
    "source": [
-    "model.fit(np.stack(xs,1), y, batch_size=64, nb_epoch=8)"
+    "model.fit(np.concatenate(xs,axis=1), y, batch_size=64, nb_epoch=8)"
    ]
   },
   {


### PR DESCRIPTION
Changing `np.stack` to `np.concatenate`.  `stack` adds an extra input dimension therefore creating the wrong dimensions for `xs` causing the following error.

```
ValueError: Error when checking model input: expected embedding_input_1 to have 2 dimensions, but got array with shape (75110, 8, 1)
```

This was issue was identified and this fix was proposed in the following thread (see the reply as well as the post). 

http://forums.fast.ai/t/lesson-6-discussion/245/14