### PR TITLE
Save and restore stdout and stderr when setting default encoding

### DIFF
--- a/deeplearning1/nbs/lesson4.ipynb
+++ b/deeplearning1/nbs/lesson4.ipynb
@@ -1791,15 +1791,17 @@
    },
    "outputs": [],
    "source": [
+    "import sys\n",
+    "stdout, stderr = sys.stdout, sys.stderr # save notebook stdout and stderr\n",
     "reload(sys)\n",
-    "sys.setdefaultencoding('utf8')"
+    "sys.setdefaultencoding('utf-8')\n",
+    "sys.stdout, sys.stderr = stdout, stderr # restore notebook stdout and stderr"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 410,
    "metadata": {
-    "collapsed": false,
     "hidden": true
    },
    "outputs": [


### PR DESCRIPTION
Previously, running this cell caused stdout and stderr to be disconnected from the notebook and redirected back to the console.

After this change, output to stdout and stderr continues to appear in the notebook.

See also:

https://stackoverflow.com/questions/25494182/print-not-showing-in-ipython-notebook-python