### PR TITLE
Ensure model_path exists before attempting to save_weights

### DIFF
--- a/deeplearning1/nbs/lesson5.ipynb
+++ b/deeplearning1/nbs/lesson5.ipynb
@@ -51,7 +51,8 @@
    },
    "outputs": [],
    "source": [
-    "model_path = 'data/imdb/models/'"
+    "model_path = 'data/imdb/models/'\n",
+    "%mkdir -p $model_path"
    ]
   },
   {


### PR DESCRIPTION
Create the directory for `model_path`, otherwise you get an error when attempting to call `save_weights`, below.