### PR TITLE
Download glove dataset from files.fast.ai

### DIFF
--- a/deeplearning1/nbs/lesson5.ipynb
+++ b/deeplearning1/nbs/lesson5.ipynb
@@ -624,7 +624,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_glove_dataset(dataset):\n",
+    "    \"\"\"Download the requested glove dataset from files.fast.ai\n",
+    "    and return a location that can be passed to load_vectors.\n",
+    "    \"\"\"\n",
+    "    # see wordvectors.ipynb for info on how these files were\n",
+    "    # generated from the original glove data.\n",
+    "    md5sums = {'6B.50d': '8e1557d1228decbda7db6dfd81cd9909',\n",
+    "               '6B.100d': 'c92dbbeacde2b0384a43014885a60b2c',\n",
+    "               '6B.200d': 'af271b46c04b0b2e41a84d8cd806178d',\n",
+    "               '6B.300d': '30290210376887dcc6d0a5a6374d8255'}\n",
+    "    glove_path = os.path.abspath('data/glove/results')\n",
+    "    %mkdir -p $glove_path\n",
+    "    return get_file(dataset,\n",
+    "                    'http://files.fast.ai/models/glove/' + dataset + '.tgz',\n",
+    "                    cache_subdir=glove_path,\n",
+    "                    md5_hash=md5sums.get(dataset, None),\n",
+    "                    untar=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "metadata": {
     "collapsed": true,
     "hidden": true
@@ -639,14 +666,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false,
     "hidden": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading data from http://files.fast.ai/models/glove/6B.50d.tgz\n",
+      "80101376/80107627 [============================>.] - ETA: 0sUntaring file...\n"
+     ]
+    }
+   ],
    "source": [
-    "vecs, words, wordidx = load_vectors('data/glove/results/6B.50d')"
+    "vecs, words, wordidx = load_vectors(get_glove_dataset('6B.50d'))"
    ]
   },
   {


### PR DESCRIPTION
Adds a new function, `get_glove_dataset`, that downloads the requested glove dataset from files.fast.ai and untars them into `data/glove/results`.