### PR TITLE
Use set_value to set the learning rate

### DIFF
--- a/deeplearning1/nbs/lesson6.ipynb
+++ b/deeplearning1/nbs/lesson6.ipynb
@@ -653,7 +653,7 @@
    },
    "outputs": [],
    "source": [
-    "model.optimizer.lr=0.000001"
+    "model.optimizer.lr.set_value(0.000001)"
    ]
   },
   {
@@ -703,7 +703,7 @@
    },
    "outputs": [],
    "source": [
-    "model.optimizer.lr=0.01"
+    "model.optimizer.lr.set_value(0.01)"
    ]
   },
   {
@@ -2586,7 +2586,7 @@
    },
    "outputs": [],
    "source": [
-    "model.optimizer.lr=1e-4"
+    "model.optimizer.lr.set_value(1e-4)"
    ]
   },
   {


### PR DESCRIPTION
If `lr` is set via normal assignment, then we get the following error later in the notebook when attempting to call `set_value` on it:

    AttributeErrorTraceback (most recent call last)
    <ipython-input-68-c065d419a30d> in <module>()
    ----> 1 model.optimizer.lr.set_value(0.000001)

    AttributeError: 'float' object has no attribute 'set_value'


Alternatively, I guess any calls to `set_value` could be converted to normal assignment.