### PR TITLE
move model.flatten above so that model compiles

### DIFF
--- a/deeplearning1/nbs/vgg16bn.py
+++ b/deeplearning1/nbs/vgg16bn.py
@@ -78,13 +78,14 @@ class Vgg16BN():
         self.ConvBlock(3, 256)
         self.ConvBlock(3, 512)
         self.ConvBlock(3, 512)
+        model.add(Flatten())
 
         if not include_top:
             fname = 'vgg16_bn_conv.h5'
             model.load_weights(get_file(fname, self.FILE_PATH+fname, cache_subdir='models'))
             return
 
-        model.add(Flatten())
+        
         self.FCBlock()
         self.FCBlock()
         model.add(Dense(1000, activation='softmax'))


### PR DESCRIPTION
Currently, the model wouldn't compile for sizes other than (224,224) when fine tuning as under the branch if not include_top, the model is not yet flattened but later in the create function, a dense layer is added (without flattening), hence, raising an error. Changing the position of the model.flatten fixes this.