### PR TITLE
remove deprecated width_zoom_range from lesson3

### DIFF
--- a/deeplearning1/nbs/lesson3.ipynb
+++ b/deeplearning1/nbs/lesson3.ipynb
@@ -571,7 +571,7 @@
     "#   which is the same order as matplotlib uses for display.\n",
     "# Therefore when just using for display purposes, this is more convenient\n",
     "gen = image.ImageDataGenerator(rotation_range=10, width_shift_range=0.1, \n",
-    "       height_shift_range=0.1, width_zoom_range=0.2, shear_range=0.15, zoom_range=0.1, \n",
+    "       height_shift_range=0.1, shear_range=0.15, zoom_range=0.1, \n",
     "       channel_shift_range=10., horizontal_flip=True, dim_ordering='tf')"
    ]
   },


### PR DESCRIPTION
It appears that `width_zoom_range` has been removed from newer versions of Keras, as it no longer appears in the [documentation for ImageDataGenerator](https://keras.io/preprocessing/image/), and running it in Jupyter produces

```
TypeError: __init__() got an unexpected keyword argument 'width_zoom_range'
```

Several users (e.g. [@ruizendaalr](https://medium.com/towards-data-science/deep-learning-3-more-on-cnns-handling-overfitting-2bd5d99abe5d) and [@Freedom89](https://github.com/Freedom89/codes_fastai)) have mentioned this hampering their progress on Lesson 3.

This PR removes the `width_zoom_range` parameter from Lesson 3, which alleviates this issue.