### PR TITLE
Replace loss_d with x_entropy_d to avoid NameError

### DIFF
--- a/deeplearning1/nbs/lesson6.ipynb
+++ b/deeplearning1/nbs/lesson6.ipynb
@@ -3409,7 +3409,7 @@
     }
    ],
    "source": [
-    "np.allclose(softmax_d(pre_pred).dot(loss_d(preds,actual)), preds-actual)"
+    "np.allclose(softmax_d(pre_pred).dot(x_entropy_d(preds,actual)), preds-actual)"
    ]
   },
   {


### PR DESCRIPTION
`loss_d` is not defined until a few cells further down in the notebook, so if you run the cells sequentially, you'll get a `NameError` when you try to run this cell. Replacing `loss_d` with `x_entropy_d` here avoids the `NameError` and gives the same result, since `loss_d=x_entropy_d`.