### PR TITLE
Use np.squeeze and np.atleast_3d to munge dimensions for {x,y}_rnn

### DIFF
--- a/deeplearning1/nbs/lesson6.ipynb
+++ b/deeplearning1/nbs/lesson6.ipynb
@@ -2171,8 +2171,8 @@
    },
    "outputs": [],
    "source": [
-    "x_rnn=np.stack(xs, axis=1)\n",
-    "y_rnn=np.expand_dims(np.stack(ys, axis=1), -1)"
+    "x_rnn=np.stack(np.squeeze(xs), axis=1)\n",
+    "y_rnn=np.atleast_3d(np.stack(ys, axis=1))"
    ]
   },
   {


### PR DESCRIPTION
If you run the cells of this notebook sequentially, then you'll get one of the following exceptions when attempting to call `model.fit` in the "Sequence model with keras" section:

    Exception: Error when checking model input: expected
    embedding_input_2 to have 2 dimensions, but got array with
    shape (75110, 8, 1)

    Exception: Error when checking model target: expected
    timedistributed_1 to have 3 dimensions, but got array with
    shape (75110, 8, 1, 1)

The problem is that `xs` and `ys` will have different dimensions depending on whether you ran all previous cells of the notebook, or whether you ran only the minimum cells required to work on the "Sequence model with keras" section.

The reason is that when you pass `xs` and `ys` as arguments to `model.fit` in previous sections, the dimensions of the underlying `ndarray`s are automatically expanded, whereas if you skip those calls to `model.fit`, the dimensions remain the same as when they were created.

The solution is to modify `x_rnn` and `y_rnn` so that they have the correct shape regardless of whether all previous cells have been run or only the cells required to define `xs` and `ys`.

To clarify, here is table showing the various shapes for `xs`, `ys`, `x_rnn`, and `y_rnn`. The "before" and "after" columns refer to the sizes before and after applying this patch, respectively. The "desired" column lists the shape that model expects.  This patch does not alter `xs` or `ys`, but their shapes are included in the table since `x_rnn` and `y_rnn` are derived from them.


### if all cells run

|             | before           | after         | desired       |
|-------------|------------------|---------------|---------------|
| xs[0].shape | (75110, 1)       | no change          | n/a           |
| ys[0].shape | (75110, 1)       | no change          | n/a           |
| x_rnn.shape | (75110, 8, 1)    | (75110, 8)    | (75110, 8)    |
| y_rnn.shape | (75110, 8, 1, 1) | (75110, 8, 1) | (75110, 8, 1) |


### if previous `model.fit` cells skipped

|             | before        | after         | desired       |
|-------------|---------------|---------------|---------------|
| xs[0].shape | (75110,)      | no change          | n/a           |
| ys[0].shape | (75110,)      | no change          | n/a           |
| x_rnn.shape | (75110, 8)    | (75110, 8)    | (75110, 8)    |
| y_rnn.shape | (75110, 8, 1) | (75110, 8, 1) | (75110, 8, 1) |