### PR TITLE
Add get_annotations and skip 'other' when loading anno_classes

### DIFF
--- a/deeplearning1/nbs/lesson7.ipynb
+++ b/deeplearning1/nbs/lesson7.ipynb
@@ -1081,6 +1081,59 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_annotations():\n",
+    "    annot_urls = {\n",
+    "        '5458/bet_labels.json': 'bd20591439b650f44b36b72a98d3ce27',\n",
+    "        '5459/shark_labels.json': '94b1b3110ca58ff4788fb659eda7da90',\n",
+    "        '5460/dol_labels.json': '91a25d29a29b7e8b8d7a8770355993de',\n",
+    "        '5461/yft_labels.json': '9ef63caad8f076457d48a21986d81ddc',\n",
+    "        '5462/alb_labels.json': '731c74d347748b5272042f0661dad37c',\n",
+    "        '5463/lag_labels.json': '92d75d9218c3333ac31d74125f2b380a'\n",
+    "    }\n",
+    "    cache_subdir = os.path.abspath(os.path.join(path, 'annos'))\n",
+    "    url_prefix = 'https://kaggle2.blob.core.windows.net/forum-message-attachments/147157/'\n",
+    "    \n",
+    "    if not os.path.exists(cache_subdir):\n",
+    "        os.makedirs(cache_subdir)\n",
+    "    \n",
+    "    for url_suffix, md5_hash in annot_urls.iteritems():\n",
+    "        fname = url_suffix.rsplit('/', 1)[-1]\n",
+    "        get_file(fname, url_prefix + url_suffix, cache_subdir=cache_subdir, md5_hash=md5_hash)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading data from https://kaggle2.blob.core.windows.net/forum-message-attachments/147157/5463/lag_labels.json\n",
+      "16384/30731 [==============>...............] - ETA: 0sDownloading data from https://kaggle2.blob.core.windows.net/forum-message-attachments/147157/5459/shark_labels.json\n",
+      "49152/68097 [====================>.........] - ETA: 0sDownloading data from https://kaggle2.blob.core.windows.net/forum-message-attachments/147157/5461/yft_labels.json\n",
+      "212992/284511 [=====================>........] - ETA: 0sDownloading data from https://kaggle2.blob.core.windows.net/forum-message-attachments/147157/5458/bet_labels.json\n",
+      "49152/82471 [================>.............] - ETA: 0sDownloading data from https://kaggle2.blob.core.windows.net/forum-message-attachments/147157/5462/alb_labels.json\n",
+      "606208/775061 [======================>.......] - ETA: 0sDownloading data from https://kaggle2.blob.core.windows.net/forum-message-attachments/147157/5460/dol_labels.json\n",
+      "16384/41584 [==========>...................] - ETA: 0s"
+     ]
+    }
+   ],
+   "source": [
+    "get_annotations()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 48,
    "metadata": {
     "collapsed": false
@@ -1089,6 +1142,7 @@
    "source": [
     "bb_json = {}\n",
     "for c in anno_classes:\n",
+    "    if c == 'other': continue # no annotation file for \"other\" class\n",
     "    j = json.load(open('{}annos/{}_labels.json'.format(path, c), 'r'))\n",
     "    for l in j:\n",
     "        if 'annotations' in l.keys() and len(l['annotations'])>0:\n",


### PR DESCRIPTION
Add a function `get_annotations` to automatically download bounding box annotation files from the kaggle fisheries competition forum.

Also, don't attempt to load annotations for the "other" class, since no annotations exist for that class. This avoids an exception when attempting to `open` the non-existent file.