### PR TITLE
Update vgg16.py

### DIFF
--- a/deeplearning1/nbs/vgg16.py
+++ b/deeplearning1/nbs/vgg16.py
@@ -164,7 +164,7 @@ class Vgg16():
         model.pop()
         for layer in model.layers: layer.trainable=False
         model.add(Dense(num, activation='softmax'))
-        self.compile()
+        model.compile()
 
     def finetune(self, batches):
         """


### PR DESCRIPTION
it seems self is a error,the vedio there use model
```
model.compile(optimizer=RMSprop(lr=0.1),
                    loss='categorical_crossentropy', metrics=['accuracy'])
```