### PR TITLE
Removing an extra new line character to make wordvectors.ipynb a valid JSON file

### DIFF
--- a/deeplearning1/nbs/wordvectors.ipynb
+++ b/deeplearning1/nbs/wordvectors.ipynb
@@ -49,8 +49,7 @@
     "hidden": true
    },
    "source": [
-    "This section shows how we processed the original glove text files. However, there's no need for you to do this,
-    since we provide the [pre-processed glove data](files.fast.ai/models/glove)."
+    "This section shows how we processed the original glove text files. However, there's no need for you to do this, since we provide the [pre-processed glove data](files.fast.ai/models/glove)."
    ]
   },
   {


### PR DESCRIPTION
Currently, an attempt to opening wordvectors.ipynb results in the following error:
![screen shot](https://user-images.githubusercontent.com/5401333/30232721-8c2949e6-94bf-11e7-9c1b-861721ebcae8.png)

Removed the extra new line character to fix this issue.
