### PR TITLE
Updates to support python3 and keras2

### DIFF
--- a/deeplearning1/nbs/utils.py
+++ b/deeplearning1/nbs/utils.py
@@ -1,6 +1,10 @@
 from __future__ import division,print_function
 import math, os, json, sys, re
-import cPickle as pickle
+import sys
+if sys.version_info.major>2:
+   import _pickle as pickle
+else:
+   import cPickle as pickle
 from glob import glob
 import numpy as np
 from matplotlib import pyplot as plt
@@ -39,10 +43,15 @@ from keras.models import Sequential, Model
 from keras.layers import Input, Embedding, Reshape, merge, LSTM, Bidirectional
 from keras.layers import TimeDistributed, Activation, SimpleRNN, GRU
 from keras.layers.core import Flatten, Dense, Dropout, Lambda
-from keras.regularizers import l2, activity_l2, l1, activity_l1
+from keras.regularizers import l2, l1
+if keras.__version__[0] == '1':
+   from keras.regularizers import activity_l2, activity_l1
 from keras.layers.normalization import BatchNormalization
 from keras.optimizers import SGD, RMSprop, Adam
-from keras.utils.layer_utils import layer_from_config
+if keras.__version__[0] == '1':
+   from keras.utils.layer_utils import layer_from_config
+else:
+   from keras.layers import deserialize as layer_from_config
 from keras.metrics import categorical_crossentropy, categorical_accuracy
 from keras.layers.convolutional import *
 from keras.preprocessing import image, sequence


### PR DESCRIPTION
I've been running your delightful and intuitive course on my machine at home (i.e. not on AWS). I ran into one or two problems in importing utils.py:

cPickle has been renamed to _pickle in python3
activity_l1 and activity_l2 are removed in keras2
keras.utils.layer_utils.layer_from_config has been replaced by
   keras.layers.deserialize in keras2