### PR TITLE
Replace "gpu" with "cuda" in theanorc

### DIFF
--- a/setup/install-gpu.sh
+++ b/setup/install-gpu.sh
@@ -29,7 +29,7 @@ conda upgrade -y --all
 # install and configure theano
 pip install theano
 echo "[global]
-device = gpu
+device = cuda
 floatX = float32
 
 [cuda]


### PR DESCRIPTION
An update to Theano has required this change. Without it, an error occurs asking the user to switch "gpu" with "cuda".

Documentation: http://deeplearning.net/software/theano/library/config.html#envvar-THEANORC

A fast.ai student ran into this error: http://forums.fast.ai/t/optimization-of-local-setup/8577