### PR TITLE
Removing DEBUG and INFO lines from the awscli command output.

### DIFF
--- a/setup/setup_instance.sh
+++ b/setup/setup_instance.sh
@@ -22,29 +22,32 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [ -z "$(aws configure get aws_access_key_id)" ]; then
+if [ -z "$(aws configure get aws_access_key_id | grep -v DEBUG )" ]; then
     echo "AWS credentials not configured.  Aborting"
     exit 1
 fi
 
-export vpcId=$(aws ec2 create-vpc --cidr-block 10.0.0.0/28 --query 'Vpc.VpcId' --output text)
+export vpcId=$(aws ec2 create-vpc --cidr-block 10.0.0.0/28 --query 'Vpc.VpcId' --output text | grep -v DEBUG | grep -v INFO)
+
 aws ec2 create-tags --resources $vpcId --tags --tags Key=Name,Value=$name
 aws ec2 modify-vpc-attribute --vpc-id $vpcId --enable-dns-support "{\"Value\":true}"
 aws ec2 modify-vpc-attribute --vpc-id $vpcId --enable-dns-hostnames "{\"Value\":true}"
 
-export internetGatewayId=$(aws ec2 create-internet-gateway --query 'InternetGateway.InternetGatewayId' --output text)
+export internetGatewayId=$(aws ec2 create-internet-gateway --query 'InternetGateway.InternetGatewayId' --output text | grep -v DEBUG | grep -v INFO)
 aws ec2 create-tags --resources $internetGatewayId --tags --tags Key=Name,Value=$name-gateway
 aws ec2 attach-internet-gateway --internet-gateway-id $internetGatewayId --vpc-id $vpcId
 
-export subnetId=$(aws ec2 create-subnet --vpc-id $vpcId --cidr-block 10.0.0.0/28 --query 'Subnet.SubnetId' --output text)
+export subnetId=$(aws ec2 create-subnet --vpc-id $vpcId --cidr-block 10.0.0.0/28 --query 'Subnet.SubnetId' --output text | grep -v DEBUG | grep -v INFO)
+echo $subnetId
+echo "Husocan"
 aws ec2 create-tags --resources $subnetId --tags --tags Key=Name,Value=$name-subnet
 
-export routeTableId=$(aws ec2 create-route-table --vpc-id $vpcId --query 'RouteTable.RouteTableId' --output text)
+export routeTableId=$(aws ec2 create-route-table --vpc-id $vpcId --query 'RouteTable.RouteTableId' --output text | grep -v DEBUG | grep -v INFO)
 aws ec2 create-tags --resources $routeTableId --tags --tags Key=Name,Value=$name-route-table
-export routeTableAssoc=$(aws ec2 associate-route-table --route-table-id $routeTableId --subnet-id $subnetId --output text)
+export routeTableAssoc=$(aws ec2 associate-route-table --route-table-id $routeTableId --subnet-id $subnetId --output text | grep -v DEBUG | grep -v INFO )
 aws ec2 create-route --route-table-id $routeTableId --destination-cidr-block 0.0.0.0/0 --gateway-id $internetGatewayId
 
-export securityGroupId=$(aws ec2 create-security-group --group-name $name-security-group --description "SG for fast.ai machine" --vpc-id $vpcId --query 'GroupId' --output text)
+export securityGroupId=$(aws ec2 create-security-group --group-name $name-security-group --description "SG for fast.ai machine" --vpc-id $vpcId --query 'GroupId' --output text | grep -v DEBUG | grep -v INFO)
 # ssh
 aws ec2 authorize-security-group-ingress --group-id $securityGroupId --protocol tcp --port 22 --cidr $cidr
 # jupyter notebook
@@ -61,15 +64,15 @@ then
 	chmod 400 ~/.ssh/aws-key-$name.pem
 fi
 
-export instanceId=$(aws ec2 run-instances --image-id $ami --count 1 --instance-type $instanceType --key-name aws-key-$name --security-group-ids $securityGroupId --subnet-id $subnetId --associate-public-ip-address --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 128, \"VolumeType\": \"gp2\" } } ]" --query 'Instances[0].InstanceId' --output text)
+export instanceId=$(aws ec2 run-instances --image-id $ami --count 1 --instance-type $instanceType --key-name aws-key-$name --security-group-ids $securityGroupId --subnet-id $subnetId --associate-public-ip-address --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 128, \"VolumeType\": \"gp2\" } } ]" --query 'Instances[0].InstanceId' --output text | grep -v DEBUG | grep -v INFO)
 aws ec2 create-tags --resources $instanceId --tags --tags Key=Name,Value=$name-gpu-machine
-export allocAddr=$(aws ec2 allocate-address --domain vpc --query 'AllocationId' --output text)
+export allocAddr=$(aws ec2 allocate-address --domain vpc --query 'AllocationId' --output text | grep -v DEBUG | grep -v INFO)
 
 echo Waiting for instance start...
 aws ec2 wait instance-running --instance-ids $instanceId
 sleep 10 # wait for ssh service to start running too
-export assocId=$(aws ec2 associate-address --instance-id $instanceId --allocation-id $allocAddr --query 'AssociationId' --output text)
-export instanceUrl=$(aws ec2 describe-instances --instance-ids $instanceId --query 'Reservations[0].Instances[0].PublicDnsName' --output text)
+export assocId=$(aws ec2 associate-address --instance-id $instanceId --allocation-id $allocAddr --query 'AssociationId' --output text | grep -v DEBUG | grep -v INFO)
+export instanceUrl=$(aws ec2 describe-instances --instance-ids $instanceId --query 'Reservations[0].Instances[0].PublicDnsName' --output text | grep -v DEBUG | grep -v INFO)
 #export ebsVolume=$(aws ec2 describe-instance-attribute --instance-id $instanceId --attribute  blockDeviceMapping  --query BlockDeviceMappings[0].Ebs.VolumeId --output text)
 
 # reboot instance, because I was getting "Failed to initialize NVML: Driver/library version mismatch"

--- a/setup/setup_p2.sh
+++ b/setup/setup_p2.sh
@@ -3,7 +3,7 @@
 # Configure a p2.xlarge instance
 
 # get the correct ami
-export region=$(aws configure get region)
+export region=$(aws configure get region | grep -v DEBUG)
 if [ $region = "us-west-2" ]; then
    export ami="ami-bc508adc" # Oregon
 elif [ $region = "eu-west-1" ]; then

--- a/setup/setup_t2.sh
+++ b/setup/setup_t2.sh
@@ -3,7 +3,8 @@
 # Configure a t2.xlarge instance
 
 # get the correct ami
-export region=$(aws configure get region)
+export region=$(aws configure get region | grep -v DEBUG)
+echo $region
 if [ $region = "us-west-2" ]; then
    export ami="ami-f8fd5998" # Oregon
 elif [ $region = "eu-west-1" ]; then


### PR DESCRIPTION
I have realized that awscli commands are producing some `DEBUG` and `INFO` output before the actual result. This results in breaking the environmental variable assignments in the set up scripts. For example, 

`aws configure get region`

returns 2 lines:
`2017-12-27 14:29:16  - awscli.customizations.configure.get - DEBUG - Config value retrieved: us-west-2
us-west-2`

To fix this, simply, I am `grep`ping for non-`DEBUG` and non-`INFO` lines. 

I am using `awscli==1.14.16`. It might some weird configuration in my machine or a new `awscli` version issue. 

Just thought you might want to know about. CC @jph00 @racheltho 