### PR TITLE
Added the HTTP to URL explicitly.

### DIFF
--- a/deeplearning2/README.md
+++ b/deeplearning2/README.md
@@ -1,3 +1,3 @@
 # Part 2: Cutting Edge Deep Learning for Coders
 
-This is the repo for [Cutting Edge Deep Learning for Coders](course.fast.ai/part2.html). See the course page for details on these notebooks and the associated videos.
+This is the repo for [Cutting Edge Deep Learning for Coders](http://course.fast.ai/part2.html). See the course page for details on these notebooks and the associated videos.


### PR DESCRIPTION
Without the explicit HTTP, clicking the link github would automatically append the url to the existing incoming url and leads to https://github.com/fastai/courses/blob/master/deeplearning2/course.fast.ai/part2.html