### PR TITLE
Replace 'creator' with 'grad_fn' and 'previous_functions' by 'next_functions'

### DIFF
--- a/deeplearning2/pytorch-tut.ipynb
+++ b/deeplearning2/pytorch-tut.ipynb
@@ -576,7 +576,7 @@
     }
    ],
    "source": [
-    "y.creator"
+    "y.grad_fn"
    ]
   },
   {
@@ -650,8 +650,8 @@
    "source": [
     "# You never have to look at these in practice - this is just showing how the\n",
     "#   computation graph is stored\n",
-    "print(out.creator.previous_functions[0][0])\n",
-    "print(out.creator.previous_functions[0][0].previous_functions[0][0])"
+    "print(out.grad_fn.next_functions[0][0])\n",
+    "print(out.grad_fn.next_functions[0][0].next_functions[0][0])"
    ]
   },
   {


### PR DESCRIPTION
 In [this](https://github.com/pytorch/pytorch/pull/1016/commits/56f294b8e599a5ce5727e73e2b1767b629677ea9) commit `creator` was changed to `grad_fn` and `previous_functions` was changed to `next_functions`.  This PR changes the pytorch tutorial accordingly.